### PR TITLE
Add a branded captcha page

### DIFF
--- a/captcha.html
+++ b/captcha.html
@@ -1,0 +1,1221 @@
+
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+  <head>
+    <title>Security check | The Texas Tribune</title>
+    <meta charset="utf-8" />
+    <link href="//cdnjs.cloudflare.com" rel="dns-prefetch" />
+    <link href="//cdn.texastribune.org" rel="dns-prefetch" />
+    <link href="//static.texastribune.org" rel="dns-prefetch" />
+    <link href="//www.googletagmanager.com" rel="dns-prefetch" />
+    <link href="//www.googletagservices.com" rel="dns-prefetch" />
+    <link href="//ajax.googleapis.com" rel="dns-prefetch" />
+    <!-- base favicons -->
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="48x48"
+      href="https://www.texastribune.org/static/images/favicon-48x48.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://www.texastribune.org/static/images/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="https://www.texastribune.org/static/images/favicon-16x16.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://www.texastribune.org/static/images/apple-touch-icon.png"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="canonical" href="https://www.texastribune.org/foo/" />
+    <meta name="copyright" content="&copy; The Texas Tribune" />
+    <meta name="publisher" content="The Texas Tribune" />
+    <meta name="robots" content="index,follow" />
+    <meta name="siteinfo" content="http://www.texastribune.org/robots.txt" />
+    <link
+      rel="apple-touch-icon"
+      href="https://www.texastribune.org/static/images/apple-touch-icon.358661eab2b3.png"
+    />
+    <meta
+      name="google-site-verification"
+      content="3EMut9KLnb_7fohrI_bDaR4py76QIWAt4uPidjagbzI"
+    />
+    <meta name="y_key" content="36169ff9ee60f3ab" />
+    <meta name="msvalidate.01" content="DB22C31255557D1E219990CA92192CBB" />
+    <meta
+      name="pocket-site-verification"
+      content="a03da537417a06100ceed0ab61a3d2"
+    />
+    <meta property="fb:app_id" content="154122474650943" />
+    <meta property="og:site_name" content="The Texas Tribune" />
+    <meta property="fb:pages" content="124434790836" />
+    <meta name="twitter:site" content="@TexasTribune" />
+    <meta property="og:url" content="https://www.texastribune.org/foo/" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://www.texastribune.org/static/css/chz-index.css"
+    />
+    <script>
+      var dataLayer = window.dataLayer || [];
+      dataLayer.push({
+        contentType: "Other",
+        contentCategory: "Other",
+      });
+    </script>
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-P5L2Z5Z");
+    </script>
+    <script>
+      window.ttGlobal = { pageType: "generic" };
+    </script>
+    <script>
+      document.documentElement.classList.remove("no-js");
+    </script>
+  </head>
+
+  <body>
+    <a
+      href="#main-tt-content"
+      class="c-button c-button--skip has-bg-teal has-text-white button button--s button--teal"
+      >Skip to main content</a
+    >
+
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-P5L2Z5Z"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe>
+    </noscript>
+
+    <div style="display: none">
+      <svg>
+        <defs />
+        <symbol id="arrow-up" viewBox="0 0 26 28">
+          <path
+            d="M25.172 15.172c0 .531-.219 1.031-.578 1.406l-1.172 1.172c-.375.375-.891.594-1.422.594s-1.047-.219-1.406-.594L16 13.172v11C16 25.297 15.062 26 14 26h-2c-1.062 0-2-.703-2-1.828v-11L5.406 17.75a1.96 1.96 0 01-2.812 0l-1.172-1.172c-.375-.375-.594-.875-.594-1.406s.219-1.047.594-1.422L11.594 3.578C11.953 3.203 12.469 3 13 3s1.047.203 1.422.578L24.594 13.75c.359.375.578.891.578 1.422z"
+          />
+        </symbol>
+        <symbol id="bars" viewBox="0 0 24 28">
+          <path
+            d="M24 21v2c0 .547-.453 1-1 1H1c-.547 0-1-.453-1-1v-2c0-.547.453-1 1-1h22c.547 0 1 .453 1 1zm0-8v2c0 .547-.453 1-1 1H1c-.547 0-1-.453-1-1v-2c0-.547.453-1 1-1h22c.547 0 1 .453 1 1zm0-8v2c0 .547-.453 1-1 1H1c-.547 0-1-.453-1-1V5c0-.547.453-1 1-1h22c.547 0 1 .453 1 1z"
+          />
+        </symbol>
+        <symbol id="bug" viewBox="0 0 174.9 200">
+          <path
+            d="M0 0v200l40.2-25.1h134.6V0H0zm125.2 139.7l-38.3-25.2-38.3 25.2 12.1-44.2L25 66.8l45.8-2.1L87 21.8l16.2 42.9 45.8 2.1-35.8 28.6 12 44.3z"
+          />
+        </symbol>
+        <symbol id="camera" viewBox="0 0 30 28">
+          <path
+            d="M15 10.5c2.484 0 4.5 2.016 4.5 4.5s-2.016 4.5-4.5 4.5-4.5-2.016-4.5-4.5 2.016-4.5 4.5-4.5zM26 4c2.203 0 4 1.797 4 4v14c0 2.203-1.797 4-4 4H4c-2.203 0-4-1.797-4-4V8c0-2.203 1.797-4 4-4h3.5l.797-2.125C8.688.844 9.906 0 11 0h8c1.094 0 2.312.844 2.703 1.875L22.5 4H26zM15 22c3.859 0 7-3.141 7-7s-3.141-7-7-7-7 3.141-7 7 3.141 7 7 7z"
+          />
+        </symbol>
+        <symbol id="caret-down" viewBox="0 0 16 28">
+          <path
+            d="M16 11a.99.99 0 01-.297.703l-7 7C8.516 18.89 8.265 19 8 19s-.516-.109-.703-.297l-7-7A.996.996 0 010 11c0-.547.453-1 1-1h14c.547 0 1 .453 1 1z"
+          />
+        </symbol>
+        <symbol id="close" viewBox="0 0 22 28">
+          <path
+            d="M20.281 20.656c0 .391-.156.781-.438 1.062l-2.125 2.125c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438L11 19.249l-4.594 4.594c-.281.281-.672.438-1.062.438s-.781-.156-1.062-.438l-2.125-2.125c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062L6.751 15l-4.594-4.594c-.281-.281-.438-.672-.438-1.062s.156-.781.438-1.062l2.125-2.125c.281-.281.672-.438 1.062-.438s.781.156 1.062.438L11 10.751l4.594-4.594c.281-.281.672-.438 1.062-.438s.781.156 1.062.438l2.125 2.125c.281.281.438.672.438 1.062s-.156.781-.438 1.062L15.249 15l4.594 4.594c.281.281.438.672.438 1.062z"
+          />
+        </symbol>
+        <symbol id="comments" viewBox="0 0 28 28">
+          <path
+            d="M22 12c0 4.422-4.922 8-11 8-.953 0-1.875-.094-2.75-.25a13.114 13.114 0 01-4.344 2 11.58 11.58 0 01-1.344.25h-.047c-.234 0-.453-.187-.5-.453-.063-.297.141-.484.313-.688.609-.688 1.297-1.297 1.828-2.594C1.625 16.796 0 14.531 0 11.999c0-4.422 4.922-8 11-8s11 3.578 11 8zm6 4c0 2.547-1.625 4.797-4.156 6.266.531 1.297 1.219 1.906 1.828 2.594.172.203.375.391.313.688-.063.281-.297.484-.547.453a11.58 11.58 0 01-1.344-.25 13.114 13.114 0 01-4.344-2c-.875.156-1.797.25-2.75.25-2.828 0-5.422-.781-7.375-2.063a20.4 20.4 0 001.375.063c3.359 0 6.531-.969 8.953-2.719C22.562 17.376 24 14.798 24 12.001c0-.812-.125-1.609-.359-2.375C26.282 11.079 28 13.392 28 16.001z"
+          />
+        </symbol>
+        <symbol id="envelope" viewBox="0 0 28 28">
+          <path
+            d="M28 11.094V23.5c0 1.375-1.125 2.5-2.5 2.5h-23A2.507 2.507 0 010 23.5V11.094c.469.516 1 .969 1.578 1.359 2.594 1.766 5.219 3.531 7.766 5.391 1.313.969 2.938 2.156 4.641 2.156h.031c1.703 0 3.328-1.188 4.641-2.156 2.547-1.844 5.172-3.625 7.781-5.391a9.278 9.278 0 001.563-1.359zM28 6.5c0 1.75-1.297 3.328-2.672 4.281-2.438 1.687-4.891 3.375-7.313 5.078-1.016.703-2.734 2.141-4 2.141h-.031c-1.266 0-2.984-1.437-4-2.141-2.422-1.703-4.875-3.391-7.297-5.078-1.109-.75-2.688-2.516-2.688-3.938 0-1.531.828-2.844 2.5-2.844h23c1.359 0 2.5 1.125 2.5 2.5z"
+          />
+        </symbol>
+        <symbol id="facebook" viewBox="0 0 16 28">
+          <path
+            d="M14.984.187v4.125h-2.453c-1.922 0-2.281.922-2.281 2.25v2.953h4.578l-.609 4.625H10.25v11.859H5.469V14.14H1.485V9.515h3.984V6.109C5.469 2.156 7.891 0 11.422 0c1.687 0 3.141.125 3.563.187z"
+          />
+        </symbol>
+        <symbol id="file-text-o" viewBox="0 0 24 28">
+          <path
+            d="M22.937 5.938c.578.578 1.062 1.734 1.062 2.562v18a1.5 1.5 0 01-1.5 1.5h-21a1.5 1.5 0 01-1.5-1.5v-25a1.5 1.5 0 011.5-1.5h14c.828 0 1.984.484 2.562 1.062zM16 2.125V8h5.875c-.094-.266-.234-.531-.344-.641L16.64 2.468c-.109-.109-.375-.25-.641-.344zM22 26V10h-6.5A1.5 1.5 0 0114 8.5V2H2v24h20zM6 12.5c0-.281.219-.5.5-.5h11c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11a.494.494 0 01-.5-.5v-1zM17.5 16c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11a.494.494 0 01-.5-.5v-1c0-.281.219-.5.5-.5h11zm0 4c.281 0 .5.219.5.5v1c0 .281-.219.5-.5.5h-11a.494.494 0 01-.5-.5v-1c0-.281.219-.5.5-.5h11z"
+          />
+        </symbol>
+        <symbol id="flag" viewBox="0 0 29 28">
+          <path
+            d="M5 4c0 .719-.391 1.359-1 1.719V25.5c0 .266-.234.5-.5.5h-1a.514.514 0 01-.5-.5V5.719c-.609-.359-1-1-1-1.719 0-1.109.891-2 2-2s2 .891 2 2zm23 1v11.922c0 .578-.359.797-.812 1.031-1.766.953-3.719 1.813-5.766 1.813-2.875 0-4.25-2.188-7.656-2.188-2.484 0-5.094 1.125-7.25 2.281A1.023 1.023 0 016 20c-.547 0-1-.453-1-1V7.406c0-.375.187-.641.484-.859.375-.25.828-.469 1.234-.672C8.687 4.875 11.077 4 13.296 4c2.453 0 4.375.812 6.547 1.828.438.219.891.297 1.375.297C23.671 6.125 26.312 4 26.999 4c.547 0 1 .453 1 1z"
+          />
+        </symbol>
+        <symbol id="info" viewBox="0 0 7 13">
+          <path
+            d="M.967 11.01c.564-1.789 1.632-3.932 1.821-4.474.273-.787-.211-1.136-1.74.209l-.34-.64c1.744-1.897 5.335-2.326 4.113.613-.763 1.835-1.309 3.074-1.621 4.03-.455 1.393.694.828 1.819-.211.153.25.203.331.356.619C2.877 13.534.104 13.744.967 11.01zm4.742-8.169c-.532.453-1.32.443-1.761-.022-.441-.465-.367-1.208.164-1.661.532-.453 1.32-.442 1.761.022.439.466.367 1.209-.164 1.661z"
+          />
+        </symbol>
+        <symbol id="instagram" viewBox="0 0 24 28">
+          <path
+            d="M16 14c0-2.203-1.797-4-4-4s-4 1.797-4 4 1.797 4 4 4 4-1.797 4-4zm2.156 0c0 3.406-2.75 6.156-6.156 6.156S5.844 17.406 5.844 14 8.594 7.844 12 7.844s6.156 2.75 6.156 6.156zm1.688-6.406c0 .797-.641 1.437-1.437 1.437S16.97 8.39 16.97 7.594s.641-1.437 1.437-1.437 1.437.641 1.437 1.437zM12 4.156c-1.75 0-5.5-.141-7.078.484-.547.219-.953.484-1.375.906s-.688.828-.906 1.375c-.625 1.578-.484 5.328-.484 7.078s-.141 5.5.484 7.078c.219.547.484.953.906 1.375s.828.688 1.375.906c1.578.625 5.328.484 7.078.484s5.5.141 7.078-.484c.547-.219.953-.484 1.375-.906s.688-.828.906-1.375c.625-1.578.484-5.328.484-7.078s.141-5.5-.484-7.078c-.219-.547-.484-.953-.906-1.375s-.828-.688-1.375-.906C17.5 4.015 13.75 4.156 12 4.156zM24 14c0 1.656.016 3.297-.078 4.953-.094 1.922-.531 3.625-1.937 5.031s-3.109 1.844-5.031 1.937c-1.656.094-3.297.078-4.953.078s-3.297.016-4.953-.078c-1.922-.094-3.625-.531-5.031-1.937S.173 20.875.08 18.953C-.014 17.297.002 15.656.002 14s-.016-3.297.078-4.953c.094-1.922.531-3.625 1.937-5.031s3.109-1.844 5.031-1.937c1.656-.094 3.297-.078 4.953-.078s3.297-.016 4.953.078c1.922.094 3.625.531 5.031 1.937s1.844 3.109 1.937 5.031C24.016 10.703 24 12.344 24 14z"
+          />
+        </symbol>
+        <symbol id="linkedin" viewBox="0 0 24 28">
+          <path
+            d="M5.453 9.766V25.25H.297V9.766h5.156zm.328-4.782c.016 1.484-1.109 2.672-2.906 2.672h-.031C1.11 7.656 0 6.468 0 4.984c0-1.516 1.156-2.672 2.906-2.672 1.766 0 2.859 1.156 2.875 2.672zM24 16.375v8.875h-5.141v-8.281c0-2.078-.75-3.5-2.609-3.5-1.422 0-2.266.953-2.641 1.875-.125.344-.172.797-.172 1.266v8.641H8.296c.063-14.031 0-15.484 0-15.484h5.141v2.25h-.031c.672-1.062 1.891-2.609 4.672-2.609 3.391 0 5.922 2.219 5.922 6.969z"
+          />
+        </symbol>
+        <symbol id="long-arrow-left" viewBox="0 0 29 28">
+          <path
+            d="M28 12.5v3c0 .281-.219.5-.5.5H8v3.5c0 .203-.109.375-.297.453s-.391.047-.547-.078l-6-5.469A.508.508 0 011 14.047c0-.141.063-.281.156-.375l6-5.531A.5.5 0 118 8.5V12h19.5c.281 0 .5.219.5.5z"
+          />
+        </symbol>
+        <symbol id="long-arrow-right" viewBox="0 0 27 28">
+          <path
+            d="M27 13.953a.549.549 0 01-.156.375l-6 5.531A.5.5 0 1120 19.5V16H.5a.494.494 0 01-.5-.5v-3c0-.281.219-.5.5-.5H20V8.5c0-.203.109-.375.297-.453s.391-.047.547.078l6 5.469a.508.508 0 01.156.359z"
+          />
+        </symbol>
+        <symbol id="reddit" viewBox="0 0 28 28">
+          <path
+            d="M17.109 18.234c.141.141.141.359 0 .484-.891.891-2.609.969-3.109.969s-2.219-.078-3.109-.969c-.141-.125-.141-.344 0-.484a.34.34 0 01.469 0c.562.578 1.781.766 2.641.766s2.063-.187 2.641-.766a.34.34 0 01.469 0zm-4.796-2.828c0 .766-.625 1.391-1.391 1.391a1.397 1.397 0 01-1.406-1.391A1.4 1.4 0 0110.922 14c.766 0 1.391.625 1.391 1.406zm6.171 0c0 .766-.625 1.391-1.406 1.391a1.394 1.394 0 01-1.391-1.391c0-.781.625-1.406 1.391-1.406a1.4 1.4 0 011.406 1.406zm3.922-1.875a1.867 1.867 0 00-1.875-1.859c-.531 0-1 .219-1.344.562-1.266-.875-2.969-1.437-4.859-1.5l.984-4.422 3.125.703c0 .766.625 1.391 1.391 1.391.781 0 1.406-.641 1.406-1.406s-.625-1.406-1.406-1.406a1.42 1.42 0 00-1.25.781l-3.453-.766c-.172-.047-.344.078-.391.25l-1.078 4.875c-1.875.078-3.563.641-4.828 1.516a1.877 1.877 0 00-1.359-.578 1.867 1.867 0 00-1.875 1.859c0 .75.438 1.375 1.062 1.687a4.024 4.024 0 00-.094.875c0 2.969 3.344 5.375 7.453 5.375 4.125 0 7.469-2.406 7.469-5.375 0-.297-.031-.609-.109-.891a1.878 1.878 0 001.031-1.672zM28 14c0 7.734-6.266 14-14 14S0 21.734 0 14 6.266 0 14 0s14 6.266 14 14z"
+          />
+        </symbol>
+        <symbol id="rss" viewBox="0 0 32 32">
+          <path
+            d="M4.259 23.467A4.265 4.265 0 000 27.719a4.25 4.25 0 004.259 4.244 4.25 4.25 0 004.265-4.244 4.265 4.265 0 00-4.265-4.252zM.005 10.873v6.133c3.993 0 7.749 1.562 10.577 4.391A14.897 14.897 0 0114.966 32h6.16c0-11.651-9.478-21.127-21.121-21.127zM.012 0v6.136C14.255 6.136 25.848 17.74 25.848 32H32C32 14.36 17.648 0 .012 0z"
+          />
+        </symbol>
+        <symbol id="search" viewBox="0 0 26 28">
+          <path
+            d="M18 13c0-3.859-3.141-7-7-7s-7 3.141-7 7 3.141 7 7 7 7-3.141 7-7zm8 13c0 1.094-.906 2-2 2a1.96 1.96 0 01-1.406-.594l-5.359-5.344a10.971 10.971 0 01-6.234 1.937c-6.078 0-11-4.922-11-11s4.922-11 11-11 11 4.922 11 11c0 2.219-.672 4.406-1.937 6.234l5.359 5.359c.359.359.578.875.578 1.406z"
+          />
+        </symbol>
+        <symbol id="sign-in" viewBox="0 0 24 28">
+          <path
+            d="M18.5 14a.99.99 0 01-.297.703l-8.5 8.5A.996.996 0 019 23.5c-.547 0-1-.453-1-1V18H1c-.547 0-1-.453-1-1v-6c0-.547.453-1 1-1h7V5.5c0-.547.453-1 1-1a.99.99 0 01.703.297l8.5 8.5A.996.996 0 0118.5 14zM24 8.5v11c0 2.484-2.016 4.5-4.5 4.5h-5a.514.514 0 01-.5-.5c0-.438-.203-1.5.5-1.5h5c1.375 0 2.5-1.125 2.5-2.5v-11C22 7.125 20.875 6 19.5 6H15c-.391 0-1 .078-1-.5 0-.438-.203-1.5.5-1.5h5C21.984 4 24 6.016 24 8.5z"
+          />
+        </symbol>
+        <symbol id="sign-out" viewBox="0 0 25 28">
+          <path
+            d="M10 22.5c0 .438.203 1.5-.5 1.5h-5A4.502 4.502 0 010 19.5v-11C0 6.016 2.016 4 4.5 4h5c.266 0 .5.234.5.5 0 .438.203 1.5-.5 1.5h-5A2.507 2.507 0 002 8.5v11C2 20.875 3.125 22 4.5 22H9c.391 0 1-.078 1 .5zM24.5 14a.99.99 0 01-.297.703l-8.5 8.5A.996.996 0 0115 23.5c-.547 0-1-.453-1-1V18H7c-.547 0-1-.453-1-1v-6c0-.547.453-1 1-1h7V5.5c0-.547.453-1 1-1a.99.99 0 01.703.297l8.5 8.5A.996.996 0 0124.5 14z"
+          />
+        </symbol>
+        <symbol id="twitter" viewBox="0 0 26 28">
+          <path
+            d="M25.312 6.375a10.85 10.85 0 01-2.531 2.609c.016.219.016.438.016.656 0 6.672-5.078 14.359-14.359 14.359-2.859 0-5.516-.828-7.75-2.266.406.047.797.063 1.219.063 2.359 0 4.531-.797 6.266-2.156a5.056 5.056 0 01-4.719-3.5c.313.047.625.078.953.078.453 0 .906-.063 1.328-.172a5.048 5.048 0 01-4.047-4.953v-.063a5.093 5.093 0 002.281.641 5.044 5.044 0 01-2.25-4.203c0-.938.25-1.797.688-2.547a14.344 14.344 0 0010.406 5.281 5.708 5.708 0 01-.125-1.156 5.045 5.045 0 015.047-5.047 5.03 5.03 0 013.687 1.594 9.943 9.943 0 003.203-1.219 5.032 5.032 0 01-2.219 2.781c1.016-.109 2-.391 2.906-.781z"
+          />
+        </symbol>
+        <symbol id="user" viewBox="0 0 20 28">
+          <path
+            d="M20 21.859C20 24.14 18.5 26 16.672 26H3.328C1.5 26 0 24.141 0 21.859 0 17.75 1.016 13 5.109 13a6.979 6.979 0 009.782 0C18.985 13 20 17.75 20 21.859zM16 8c0 3.313-2.688 6-6 6s-6-2.688-6-6 2.688-6 6-6 6 2.688 6 6z"
+          />
+        </symbol>
+        <symbol id="volume-up" viewBox="0 0 26 28">
+          <path
+            d="M12 5.5v17c0 .547-.453 1-1 1a.99.99 0 01-.703-.297L5.094 18H1c-.547 0-1-.453-1-1v-6c0-.547.453-1 1-1h4.094l5.203-5.203A.996.996 0 0111 4.5c.547 0 1 .453 1 1zm6 8.5c0 1.563-.953 3.078-2.422 3.672a.869.869 0 01-.391.078c-.547 0-1-.438-1-1 0-1.188 1.813-.859 1.813-2.75s-1.813-1.563-1.813-2.75c0-.562.453-1 1-1 .125 0 .266.016.391.078C17.047 10.906 18 12.437 18 14zm4 0c0 3.172-1.906 6.125-4.844 7.359a1.158 1.158 0 01-.391.078 1.01 1.01 0 01-1.016-1c0-.438.25-.734.609-.922.422-.219.812-.406 1.188-.688 1.547-1.125 2.453-2.922 2.453-4.828s-.906-3.703-2.453-4.828c-.375-.281-.766-.469-1.188-.688-.359-.187-.609-.484-.609-.922 0-.547.453-1 1-1 .141 0 .281.031.406.078 2.938 1.234 4.844 4.188 4.844 7.359zm4 0c0 4.797-2.859 9.141-7.266 11.031a1.172 1.172 0 01-.406.078c-.547 0-1-.453-1-1 0-.453.234-.703.609-.922.219-.125.469-.203.703-.328.438-.234.875-.5 1.281-.797 2.562-1.891 4.078-4.875 4.078-8.062s-1.516-6.172-4.078-8.062a11.006 11.006 0 00-1.281-.797c-.234-.125-.484-.203-.703-.328-.375-.219-.609-.469-.609-.922 0-.547.453-1 1-1 .141 0 .281.031.406.078A12.009 12.009 0 0126 14z"
+          />
+        </symbol>
+        <symbol id="your-texas" viewBox="0 0 500 500">
+          <path
+            d="M270.19 448.13l-79.76-143.39-66.32 42.04L15 211h127.16V23.6h114.9v96.95l195.47 19.06L485 259.33l-11.46 53.57-124.58 87.57 9.54 75.93z"
+          />
+        </symbol>
+        <symbol id="youtube" viewBox="0 0 24 28">
+          <path
+            d="M15.172 19.437v3.297c0 .703-.203 1.047-.609 1.047-.234 0-.469-.109-.703-.344v-4.703c.234-.234.469-.344.703-.344.406 0 .609.359.609 1.047zm5.281.016v.719h-1.406v-.719c0-.703.234-1.062.703-1.062s.703.359.703 1.062zM5.359 16.047h1.672v-1.469H2.156v1.469h1.641v8.891H5.36v-8.891zm4.5 8.891h1.391v-7.719H9.859v5.906c-.313.438-.609.656-.891.656-.187 0-.297-.109-.328-.328-.016-.047-.016-.219-.016-.547v-5.688H7.233v6.109c0 .547.047.906.125 1.141.125.391.453.578.906.578.5 0 1.031-.313 1.594-.953v.844zm6.703-2.313v-3.078c0-.719-.031-1.234-.141-1.547-.172-.578-.562-.875-1.109-.875-.516 0-1 .281-1.453.844v-3.391h-1.391v10.359h1.391v-.75c.469.578.953.859 1.453.859.547 0 .938-.297 1.109-.859.109-.328.141-.844.141-1.563zm5.282-.156v-.203h-1.422c0 .562-.016.875-.031.953-.078.375-.281.562-.625.562-.484 0-.719-.359-.719-1.078v-1.359h2.797v-1.609c0-.828-.141-1.422-.422-1.813-.406-.531-.953-.797-1.656-.797-.719 0-1.266.266-1.672.797-.297.391-.438.984-.438 1.813v2.703c0 .828.156 1.437.453 1.813.406.531.953.797 1.687.797s1.313-.281 1.687-.828a1.8 1.8 0 00.328-.844c.031-.141.031-.453.031-.906zm-9.5-14.266V4.922c0-.719-.203-1.078-.672-1.078-.453 0-.672.359-.672 1.078v3.281c0 .719.219 1.094.672 1.094.469 0 .672-.375.672-1.094zm11.234 11.735c0 1.797-.016 3.719-.406 5.469-.297 1.234-1.297 2.141-2.5 2.266-2.875.328-5.781.328-8.672.328s-5.797 0-8.672-.328c-1.203-.125-2.219-1.031-2.5-2.266-.406-1.75-.406-3.672-.406-5.469 0-1.813.016-3.719.406-5.469.297-1.234 1.297-2.141 2.516-2.281 2.859-.313 5.766-.313 8.656-.313s5.797 0 8.672.313c1.203.141 2.219 1.047 2.5 2.281.406 1.75.406 3.656.406 5.469zM7.984 0h1.594L7.687 6.234v4.234H6.124V6.234c-.141-.766-.453-1.859-.953-3.313-.344-.969-.688-1.953-1.016-2.922h1.656L6.92 4.108zm5.782 5.203v2.734c0 .828-.141 1.453-.438 1.844-.391.531-.938.797-1.656.797-.703 0-1.25-.266-1.641-.797-.297-.406-.438-1.016-.438-1.844V5.203c0-.828.141-1.437.438-1.828.391-.531.938-.797 1.641-.797.719 0 1.266.266 1.656.797.297.391.438 1 .438 1.828zM19 2.672v7.797h-1.422V9.61c-.562.656-1.094.969-1.609.969-.453 0-.781-.187-.922-.578-.078-.234-.125-.609-.125-1.172V2.673h1.422v5.734c0 .328 0 .516.016.547.031.219.141.344.328.344.281 0 .578-.219.891-.672V2.673h1.422z"
+          />
+        </symbol>
+      </svg>
+    </div>
+
+    <nav
+      class="c-navbar c-navbar--dark grid_separator has-b-btm-marg has-bg-black-off"
+    >
+      <div class="c-navbar__top l-align-center-x c-navbar__top--standard">
+        <a
+          href="/"
+          class="c-navbar__logo l-align-center-self"
+          aria-label="The Texas Tribune Homepage"
+        >
+          <svg
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 585.7 64.51"
+            class="l-display-block l-width-full"
+          >
+            <path
+              fill="#fff"
+              d="M84.94 10.23v45.85H74.63V10.23H64.49V1.16H95v9.07zM120.08 56.08V33.57h-11.46v22.51H98.39V1.16h10.23v23.25h11.46V1.16h10.31v54.92zM136.78 56.08V1.16H163V10h-16v13.59h11.05v8.08H147v15.26h16v9.15zM198.62 10.23v45.85h-10.31V10.23h-10.14V1.16h30.51v9.07zM213.1 56.08V1.16h26.23V10h-16v13.59h11v8.08h-11v15.26h16v9.15zM265.89 56.08l-6.44-19-7 19h-10l11.29-27.71-10.62-27.21h10.73l6 19 6.59-19h10.07l-11 26.39 11.05 28.53zM301.7 56.08l-1.81-10.8h-9.73l-2 10.8h-9.57l11.07-54.92h11.47l11 54.92zM295.27 16l-3.71 21.2h7zM328.66 57.32c-9.4 0-15.25-5.61-15.25-14.19v-3.79h9.4v3.22c0 4 1.9 6.26 5.61 6.26s5.44-2.14 5.44-5.52c0-4.37-2.8-7.34-8.25-11.38-5.6-4-11.71-9.49-11.71-17.15C313.9 6.85 319 0 328.91 0c8.66 0 14.43 5.94 14.43 14.1v3.55H334v-3.3c0-3.38-1.72-5.85-5.19-5.85a4.63 4.63 0 0 0-4.95 4.94c0 4.62 2.72 7 8.82 11.47 6.52 4.86 11.14 9.81 11.14 17.23.02 8.86-6.08 15.18-15.16 15.18zM377.84 10.23v45.85h-10.31V10.23h-10.15V1.16h30.52v9.07zM417.57 56.41c-4.05 0-5.61-3.3-5.61-8.08V38c0-2.56-1.32-4.7-4.21-4.7h-5.36v22.78h-10.22V1.16h16.9c7.51 0 12.54 4.29 12.54 12v7.76c0 4.12-1.9 7.17-6.19 8.49a8.42 8.42 0 0 1 6.35 8.33v10.01a7.69 7.69 0 0 0 2 5.61v3zm-5.94-42.88c0-2.48-1.07-4-3.63-4h-5.61v16.2h5.2c2.64 0 4-1.4 4-4.37zM429.8 56.08V1.16H440v54.92zM465.59 56.08h-17.32V1.16h17.16c7.5 0 12.12 4 12.12 11.62v5.94c0 4.7-1.81 8.25-6.51 9.24 4.95 1.32 6.76 4.7 6.76 9.32v7.17c0 7.67-4.7 11.63-12.21 11.63zm2.15-42.55c0-2.48-1.08-4-3.63-4h-5.53v15.13h5.12c2.63 0 4-1.4 4-4.29zm.16 23c0-2.89-1.4-4.37-4-4.37h-5.28v15.5h5.78c2.55 0 3.54-1.4 3.54-4zM499.34 57.32c-8.9 0-15.5-5.69-15.5-13.94V1.16h10.39v42.22c0 3.22 1.81 5 5.11 5s5.2-1.81 5.2-5V1.16h10v42.22c-.02 8.25-6.29 13.94-15.2 13.94zM544.66 56.08L534 32.66l-3.87-8.74v32.16h-9.4V1.16h8.82L539.71 25l3.63 8.74V1.16h9.24v54.92zM559.48 56.08V1.16h26.22V10h-16v13.59h11v8.08h-11v15.26h16v9.15z"
+            />
+            <path
+              d="M0 .6v63.91l12.85-8h43V.6zm40 44.63l-12.22-8.06-12.24 8.06 3.88-14.13L8 22l14.63-.68 5.15-13.76L33 21.27l14.58.73-11.44 9.1z"
+              fill="#ffc200"
+            />
+          </svg>
+        </a>
+
+        <div class="c-navbar__content">
+          <ul
+            class="c-navbar__items t-uppercase t-size-xxs hide_until--l is-hidden-until-bp-l js-toggle-on-search"
+          >
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="/topics/texas-tribune-investigations/"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="investigations"
+                >Investigations</a
+              >
+            </li>
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="/about/subscribe/"
+                ga-on="click"
+                ga-event-category="subscribe intent"
+                ga-event-action="top nav click"
+                ga-event-label="not frontpage"
+                >Newsletters</a
+              >
+            </li>
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="/events/"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="events"
+                >Events</a
+              >
+            </li>
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="/audio/"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="audio"
+                >Audio</a
+              >
+            </li>
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="/series/news-apps-graphics-databases/"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="data"
+                >Data</a
+              >
+            </li>
+            <li class="c-navbar__item">
+              <a
+                class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated"
+                href="https://support.texastribune.org/donate?installmentPeriod=once&amount=60"
+                ga-on="click"
+                ga-event-category="donations"
+                ga-event-action="membership-intent"
+                ga-event-label="c-navbar"
+                ><span class="has-text-yellow">Donate</span></a
+              >
+            </li>
+          </ul>
+          <ul
+            class="c-navbar__items c-navbar__items--no-space js-toggle-on-search hide_until--l is-hidden-until-bp-l"
+          >
+            <li class="c-navbar__items">
+              <ul
+                id="greeting"
+                class="c-navbar__items t-uppercase t-size-xxs hide_until--l is-hidden-until-bp-l js-toggle-on-search"
+              ></ul>
+            </li>
+            <li class="c-navbar__item">
+              <button
+                id="nav-search-open"
+                class="c-navbar__item-content c-navbar__clickable"
+                aria-label="Show site search form"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="search-open"
+              >
+                <span class="c-icon t-size-s"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#search"></use></svg
+                ></span>
+              </button>
+            </li>
+          </ul>
+
+          <ul
+            class="c-navbar__items t-size-xxs hide_from--l is-hidden-from-bp-l"
+          >
+            <li
+              id="nav-menu-open"
+              class="c-navbar__item c-navbar__item--no-space"
+            >
+              <button
+                class="c-navbar__item-content c-navbar__text c-navbar__clickable has-text-gray-light t-uppercase"
+                aria-label="Show menu"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="menu-open"
+              >
+                <span class="c-icon c-icon--yellow t-size-s"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#bars"></use></svg
+                ></span>
+                <span>&nbsp;Menu</span>
+              </button>
+            </li>
+            <li id="nav-menu-close" class="c-navbar__item hidden">
+              <button
+                class="c-navbar__item-content c-navbar__text c-navbar__clickable has-text-gray-light t-uppercase"
+                aria-label="Hide menu"
+                ga-on="click"
+                ga-event-category="navigation"
+                ga-event-action="top nav click"
+                ga-event-label="menu-close"
+              >
+                <span class="c-icon c-icon--yellow t-size-s"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#close"></use></svg
+                ></span>
+                <span>&nbsp;Close</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div
+          id="nav-search-form"
+          class="c-navbar__search hidden hide_until--l is-hidden-until-bp-l"
+        >
+          <form class="c-navbar__search-form" method="get" action="/search/">
+            <button
+              class="c-navbar__search-button c-navbar__clickable"
+              type="submit"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="search-submit"
+            >
+              <span class="c-icon t-size-s"
+                ><svg aria-hidden="true">
+                  <use xlink:href="#search"></use></svg
+              ></span>
+            </button>
+            <input
+              class="js-search-input c-navbar__search-input"
+              name="q"
+              type="text"
+              placeholder="Search The Texas Tribune"
+              aria-label="Search The Texas Tribune"
+            />
+
+            <button
+              id="nav-search-close"
+              class="c-navbar__clickable"
+              type="button"
+              aria-label="Close site search form"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="search-close"
+            >
+              <span class="c-icon c-icon--yellow t-size-s"
+                ><svg aria-hidden="true">
+                  <use xlink:href="#close"></use></svg
+              ></span>
+            </button>
+          </form>
+        </div>
+      </div>
+      <div
+        id="nav-dropdown"
+        class="c-navbar__dropdown hide_from--l is-hidden-from-bp-l hidden"
+      >
+        <div
+          class="c-navbar__dropdown-search grid_separator has-b-btm-marg l-width-full"
+        >
+          <form class="c-navbar__search-form" method="get" action="/search/">
+            <button
+              class="c-navbar__search-button c-navbar__clickable"
+              type="submit"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="search-submit"
+            >
+              <span class="c-icon t-size-s"
+                ><svg aria-hidden="true">
+                  <use xlink:href="#search"></use></svg
+              ></span>
+            </button>
+            <input
+              class="js-search-input c-navbar__search-input"
+              name="q"
+              type="text"
+              placeholder="Search The Texas Tribune"
+              aria-label="Search The Texas Tribune"
+            />
+          </form>
+        </div>
+
+        <ul class="c-navbar__dropdown-items t-uppercase t-size-xxs">
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="https://support.texastribune.org/donate?installmentPeriod=once&amount=60"
+              ga-on="click"
+              ga-event-category="donations"
+              ga-event-action="membership-intent"
+              ga-event-label="c-navbar"
+              ><span class="has-text-yellow">Donate</span></a
+            >
+          </li>
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="topics/texas-tribune-investigations/"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="investigations"
+              >Investigations</a
+            >
+          </li>
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="/about/subscribe/"
+              ga-on="click"
+              ga-event-category="subscribe intent"
+              ga-event-action="top nav click"
+              ga-event-label="not frontpage"
+              >Newsletters</a
+            >
+          </li>
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="/events/"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="events"
+              >Events</a
+            >
+          </li>
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="/audio/"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="audio"
+              >Audio</a
+            >
+          </li>
+          <li class="c-navbar__dropdown-item">
+            <a
+              class="c-navbar__clickable"
+              href="/series/news-apps-graphics-databases/"
+              ga-on="click"
+              ga-event-category="navigation"
+              ga-event-action="top nav click"
+              ga-event-label="data"
+              >Data</a
+            >
+          </li>
+        </ul>
+        <ul
+          id="mobile-greeting"
+          class="c-navbar__dropdown-items t-uppercase t-size-xxs"
+        ></ul>
+      </div>
+    </nav>
+
+    <script>
+      (function () {
+        function bindSearchOpen(elements) {
+          var searchOpen = elements.searchOpen;
+          var searchForm = elements.searchForm;
+          var searchInput = elements.searchInput;
+          var toggleOnSearch = elements.toggleOnSearch;
+
+          searchOpen.addEventListener("click", function () {
+            searchForm.classList.remove("hidden");
+            toggleOnSearch.forEach(function (el) {
+              el.classList.add("hidden");
+              searchInput.focus();
+            });
+          });
+        }
+
+        function bindSearchClose(elements) {
+          var searchClose = elements.searchClose;
+          var searchForm = elements.searchForm;
+          var toggleOnSearch = elements.toggleOnSearch;
+
+          searchClose.addEventListener("click", function () {
+            searchForm.classList.add("hidden");
+            toggleOnSearch.forEach(function (el) {
+              el.classList.remove("hidden");
+            });
+          });
+        }
+
+        function bindMenuOpen(elements) {
+          var menuOpen = elements.menuOpen;
+          var menuClose = elements.menuClose;
+          var dropdown = elements.dropdown;
+
+          menuOpen.addEventListener("click", function () {
+            menuOpen.classList.add("hidden");
+            menuClose.classList.remove("hidden");
+            dropdown.classList.remove("hidden");
+          });
+        }
+
+        function bindMenuClose(elements) {
+          var menuOpen = elements.menuOpen;
+          var menuClose = elements.menuClose;
+          var dropdown = elements.dropdown;
+
+          menuClose.addEventListener("click", function () {
+            menuOpen.classList.remove("hidden");
+            menuClose.classList.add("hidden");
+            dropdown.classList.add("hidden");
+          });
+        }
+
+        function getElements() {
+          var toggleOnSearch = document.querySelectorAll(
+            ".js-toggle-on-search"
+          );
+          var menuOpen = document.querySelector("#nav-menu-open");
+          var menuClose = document.querySelector("#nav-menu-close");
+          var searchForm = document.querySelector("#nav-search-form");
+          var searchInput = document.querySelector(".js-search-input");
+          var searchOpen = document.querySelector("#nav-search-open");
+          var searchClose = document.querySelector("#nav-search-close");
+          var dropdown = document.querySelector("#nav-dropdown");
+
+          return {
+            toggleOnSearch: toggleOnSearch,
+            menuOpen: menuOpen,
+            menuClose: menuClose,
+            searchForm: searchForm,
+            searchInput: searchInput,
+            searchOpen: searchOpen,
+            searchClose: searchClose,
+            dropdown: dropdown,
+          };
+        }
+
+        function bindNavEvents() {
+          const elements = getElements();
+          bindSearchOpen(elements);
+          bindSearchClose(elements);
+          bindMenuOpen(elements);
+          bindMenuClose(elements);
+        }
+
+        bindNavEvents();
+      })();
+    </script>
+
+    <main
+      id="main-tt-content"
+      class="has-page-padding l-container l-container--s has-xxl-btm-marg"
+    >
+      <h1 class="t-headline t-serif t-lh-m has-b-btm-marg">One moment...</h1>
+      <div class="has-bg-yellow has-notch has-xxl-btm-marg"></div>
+      <h2 class="has-b-btm-marg t-size-m t-lh-b">
+        🔒 We are verifying your browser.
+      </h2>
+      ::CAPTCHA_BOX::
+    </main>
+
+    <footer
+      id="site_footer"
+      class="c-site-footer has-bg-black-off has-text-white t-size-xs"
+    >
+      <div
+        class="l-container c-site-footer__inner c-site-footer__inner--standard"
+      >
+        <div class="c-site-footer__col c-site-footer__col--1">
+          <span
+            class="c-icon c-icon--yellow c-site-footer__logo has-giant-btm-marg"
+            style="font-size: 4rem"
+          >
+            <svg aria-hidden="true"><use xlink:href="#bug"></use></svg>
+          </span>
+          <div
+            class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg"
+          ></div>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+            <li class="has-text-blue">
+              <!-- Default -->
+              <a
+                href="https://support.texastribune.org/donate?installmentPeriod=once&amount=60"
+                title="Donate"
+                class="donate"
+                ga-on="click"
+                ga-event-category="donations"
+                ga-event-action="membership-intent"
+                ga-event-label="footer"
+                >Donate</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://support.texastribune.org/account/"
+                title="View your giving history"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="view your giving history"
+              >View your giving history
+              </a>
+            </li>
+            <li>
+              <a
+                href="/contact/"
+                title="Contact us"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="contact us"
+                >Contact us</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://mediakit.texastribune.org/"
+                title="Advertise"
+                class="advertise"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="advertise"
+                >Advertise</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://www.texastribune.org/about/tips/"
+                title="Send a Tip"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="send us a confidential tip"
+                >Send us a confidential tip</a
+              >
+            </li>
+            <li>
+              <a
+                href="/"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="copyright"
+                >&copy; <span id="copyright-year"></span> The Texas Tribune</a
+              >
+            </li>
+          </ul>
+        </div>
+        <section
+          id="footer-sections"
+          class="c-site-footer__col c-site-footer__col--2 is-hidden-until-bp-m"
+        >
+          <h2
+            class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+          >
+            Topics
+          </h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+            <li>
+              <a
+                href="/topics/congress/"
+                data-section="congress"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="congress"
+                >Congress</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/courts/"
+                data-section="courts"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="courts"
+                >Courts</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/criminal-justice/"
+                data-section="criminal-justice"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="criminal justice"
+                >Criminal justice</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/demographics/"
+                data-section="demographics"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="demographics"
+                >Demographics</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/economy/"
+                data-section="economy"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="economy"
+                >Economy</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/energy/"
+                data-section="energy"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="energy"
+                >Energy</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/environment/"
+                data-section="environment"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="environment"
+                >Environment</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/health-care/"
+                data-section="health-care"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="health care"
+                >Health care</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/higher-education/"
+                data-section="higher-education"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="higher education"
+                >Higher education</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/immigration/"
+                data-section="immigration"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="immigration"
+                >Immigration</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/politics/"
+                data-section="politics"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="politics"
+                >Politics</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/public-education/"
+                data-section="public-education"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="public education"
+                >Public education</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/state-government/"
+                data-section="state-government"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="state government"
+                >State government</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/transportation/"
+                data-section="transportation"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="transportation"
+                >Transportation</a
+              >
+            </li>
+            <li>
+              <a
+                href="/topics/"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="topics"
+                >View all</a
+              >
+            </li>
+          </ul>
+        </section>
+        <section class="c-site-footer__col c-site-footer__col--3">
+          <h2
+            class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+          >
+            <span class="is-sr-only">Company </span>Info
+          </h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+            <li>
+              <a
+                href="/about/"
+                title="About Us"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="about us"
+                >About Us</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/staff/"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="our staff"
+                >Our Staff</a
+              >
+            </li>
+            <li>
+              <a
+                href="/jobs/"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="jobs"
+                >Jobs</a
+              >
+            </li>
+            <li>
+              <a
+                href="/support-us/donors-and-members/"
+                title="Who Funds Us?"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="who funds us"
+                >Who Funds Us?</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/texas-tribune-strategic-plan/"
+                title="Strategic Plan"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="strategic plan"
+                >Strategic Plan</a
+              >
+            </li>
+            <li>
+              <a
+                href="/republishing-guidelines/"
+                title="Republishing Guidelines"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="republishing guidelines"
+                >Republishing Guidelines</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/ethics/"
+                title="Code of Ethics"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="code of ethics"
+                >Code of Ethics</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/terms-of-service/"
+                title="Terms of Service"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="terms of service"
+                >Terms of Service</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/privacy-policy/"
+                title="Privacy Policy"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="privacy policy"
+                >Privacy Policy</a
+              >
+            </li>
+
+            <li>
+              <a
+                href="https://revlab.org"
+                title="RevLab"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="revlab"
+                >RevLab</a
+              >
+            </li>
+            <li>
+              <a
+                href="/corrections/"
+                title="Corrections"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="corrections"
+                >Corrections</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/feeds/"
+                title="Feeds"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="feeds"
+                >Feeds</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about/subscribe/"
+                title="Newsletters"
+                ga-event-category="subscribe intent"
+                ga-event-action="footer link"
+                >Newsletters</a
+              >
+            </li>
+            <li>
+              <a
+                href="/audio/"
+                title="Audio"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="audio"
+                >Audio</a
+              >
+            </li>
+            <li>
+              <a
+                href="/video/"
+                title="Video"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="video"
+                >Video</a
+              >
+            </li>
+          </ul>
+        </section>
+        <section class="c-site-footer__col c-site-footer__col--4">
+          <h2
+            class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg"
+          >
+            Social Media
+          </h2>
+          <ul class="c-site-footer__links c-site-footer__links--standard">
+            <li>
+              <a
+                href="https://facebook.com/texastribune"
+                title="Facebook"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="facebook"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#facebook"></use></svg
+                ></span>
+                Facebook</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://twitter.com/texastribune"
+                title="Twitter"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="twitter"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#twitter"></use></svg
+                ></span>
+                Twitter</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://youtube.com/user/thetexastribune?sub_confirmation=1"
+                title="YouTube"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="youtube"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#youtube"></use></svg
+                ></span>
+                YouTube</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://instagram.com/texas_tribune"
+                title="Instagram"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="instagram"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#instagram"></use></svg
+                ></span>
+                Instagram</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://www.linkedin.com/company/texas-tribune"
+                title="LinkedIn"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="linkedin"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#linkedin"></use></svg
+                ></span>
+                LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://www.reddit.com/user/texastribune"
+                title="Reddit"
+                class="external has-xxs-btm-marg l-display-ib"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="reddit"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#reddit"></use></svg
+                ></span>
+                Reddit</a
+              >
+            </li>
+            <li>
+              <div
+                class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-s-btm-marg"
+              ></div>
+            </li>
+            <li>
+              <a
+                href="https://www.facebook.com/groups/thisisyourtexas/"
+                title="This is Your Texas"
+                class="external"
+                ga-event-category="navigation"
+                ga-event-action="footer link click"
+                ga-event-label="this is your texas"
+                ><span class="c-icon c-icon--baseline c-site-footer__icon"
+                  ><svg aria-hidden="true">
+                    <use xlink:href="#your-texas"></use></svg
+                ></span>
+                Join our Facebook Group, This Is Your Texas.</a
+              >
+            </li>
+          </ul>
+        </section>
+      </div>
+    </footer>
+
+    <!-- START Parse.ly Include: Standard -->
+    <div id="parsely-root" style="display: none">
+      <div id="parsely-cfg" data-parsely-site="texastribune.org"></div>
+    </div>
+    <script>
+      /** Update copyright year with current year */
+      "use strict";
+      var currentYear = new Date().getFullYear();
+      var el = document.getElementById("copyright-year");
+      el.textContent = currentYear;
+    </script>
+    <script>
+      (function (s, p, d) {
+        var h = d.location.protocol,
+          i = p + "-" + s,
+          e = d.getElementById(i),
+          r = d.getElementById(p + "-root"),
+          u =
+            h === "https:"
+              ? "d1z2jf7jlzjs58.cloudfront.net"
+              : "static." + p + ".com";
+        if (e) return;
+        e = d.createElement(s);
+        e.id = i;
+        e.async = true;
+        e.src = h + "//" + u + "/p.js";
+        r.appendChild(e);
+      })("script", "parsely", document);
+    </script>
+    <!-- END Parse.ly Include -->
+    <a href="/test/hotbots/" aria-hidden="true" rel="nofollow" tabindex="-1">
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
This is a new Cloudflare template that looks like this:
<img width="1400" alt="Screen Shot 2023-05-03 at 4 35 59 PM" src="https://user-images.githubusercontent.com/2974713/236056541-70667765-759f-4cd6-8930-0d327ef13c6b.png">

**Tech debt note:**
- Adding this new file to this repo is a bit of a weird smell. It's departure from this repo storing _just_ our 500 page. We should reconsider renaming the repo to create more [Cloudflare custom pages](https://developers.cloudflare.com/support/more-dashboard-apps/cloudflare-custom-pages/configuring-custom-pages-error-and-challenge/).
- Hard coding the full template this way is also not realistic to maintain. A future PR should address this.

