### PR TITLE
🦶 Remove revlab from site footer

### DIFF
--- a/new.html
+++ b/new.html
@@ -1009,17 +1009,6 @@
                 >Privacy Policy</a
               >
             </li>
-
-            <li>
-              <a
-                href="https://revlab.org"
-                title="RevLab"
-                ga-event-category="navigation"
-                ga-event-action="footer link click"
-                ga-event-label="revlab"
-                >RevLab</a
-              >
-            </li>
             <li>
               <a
                 href="/corrections/"


### PR DESCRIPTION
Removes the revlab link in the footer. Similar to [this PR](https://github.com/texastribune/texastribune/pull/5028).